### PR TITLE
Use default parameters

### DIFF
--- a/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -38,6 +38,69 @@ public enum NVActivityIndicatorType {
     case Pacman
     case BallGridBeat
     case SemiCircleSpin
+    
+    private func animation() -> NVActivityIndicatorAnimationDelegate {
+        switch self {
+        case .Blank:
+            return NVActivityIndicatorAnimationBlank()
+        case .BallPulse:
+            return NVActivityIndicatorAnimationBallPulse()
+        case .BallGridPulse:
+            return NVActivityIndicatorAnimationBallGridPulse()
+        case .BallClipRotate:
+            return NVActivityIndicatorAnimationBallClipRotate()
+        case .SquareSpin:
+            return NVActivityIndicatorAnimationSquareSpin()
+        case .BallClipRotatePulse:
+            return NVActivityIndicatorAnimationBallClipRotatePulse()
+        case .BallClipRotateMultiple:
+            return NVActivityIndicatorAnimationBallClipRotateMultiple()
+        case .BallPulseRise:
+            return NVActivityIndicatorAnimationBallPulseRise()
+        case .BallRotate:
+            return NVActivityIndicatorAnimationBallRotate()
+        case .CubeTransition:
+            return NVActivityIndicatorAnimationCubeTransition()
+        case .BallZigZag:
+            return NVActivityIndicatorAnimationBallZigZag()
+        case .BallZigZagDeflect:
+            return NVActivityIndicatorAnimationBallZigZagDeflect()
+        case .BallTrianglePath:
+            return NVActivityIndicatorAnimationBallTrianglePath()
+        case .BallScale:
+            return NVActivityIndicatorAnimationBallScale()
+        case .LineScale:
+            return NVActivityIndicatorAnimationLineScale()
+        case .LineScaleParty:
+            return NVActivityIndicatorAnimationLineScaleParty()
+        case .BallScaleMultiple:
+            return NVActivityIndicatorAnimationBallScaleMultiple()
+        case .BallPulseSync:
+            return NVActivityIndicatorAnimationBallPulseSync()
+        case .BallBeat:
+            return NVActivityIndicatorAnimationBallBeat()
+        case .LineScalePulseOut:
+            return NVActivityIndicatorAnimationLineScalePulseOut()
+        case .LineScalePulseOutRapid:
+            return NVActivityIndicatorAnimationLineScalePulseOutRapid()
+        case .BallScaleRipple:
+            return NVActivityIndicatorAnimationBallScaleRipple()
+        case .BallScaleRippleMultiple:
+            return NVActivityIndicatorAnimationBallScaleRippleMultiple()
+        case .BallSpinFadeLoader:
+            return NVActivityIndicatorAnimationBallSpinFadeLoader()
+        case .LineSpinFadeLoader:
+            return NVActivityIndicatorAnimationLineSpinFadeLoader()
+        case .TriangleSkewSpin:
+            return NVActivityIndicatorAnimationTriangleSkewSpin()
+        case .Pacman:
+            return NVActivityIndicatorAnimationPacman()
+        case .BallGridBeat:
+            return NVActivityIndicatorAnimationBallGridBeat()
+        case .SemiCircleSpin:
+            return NVActivityIndicatorAnimationSemiCircleSpin()
+        }
+    }
 }
 
 public class NVActivityIndicatorView: UIView {
@@ -114,74 +177,11 @@ public class NVActivityIndicatorView: UIView {
     }
     
     // MARK: Privates
-    
+
     private func setUpAnimation() {
-        let animation: protocol<NVActivityIndicatorAnimationDelegate> = animationOfType(self.type)
+        let animation: protocol<NVActivityIndicatorAnimationDelegate> = self.type.animation()
         
         self.layer.sublayers = nil
         animation.setUpAnimationInLayer(self.layer, size: self.size, color: self.color)
-    }
-    
-    private func animationOfType(type: NVActivityIndicatorType) -> protocol<NVActivityIndicatorAnimationDelegate> {
-        switch type {
-        case .Blank:
-            return NVActivityIndicatorAnimationBlank()
-        case .BallPulse:
-            return NVActivityIndicatorAnimationBallPulse()
-        case .BallGridPulse:
-            return NVActivityIndicatorAnimationBallGridPulse()
-        case .BallClipRotate:
-            return NVActivityIndicatorAnimationBallClipRotate()
-        case .SquareSpin:
-            return NVActivityIndicatorAnimationSquareSpin()
-        case .BallClipRotatePulse:
-            return NVActivityIndicatorAnimationBallClipRotatePulse()
-        case .BallClipRotateMultiple:
-            return NVActivityIndicatorAnimationBallClipRotateMultiple()
-        case .BallPulseRise:
-            return NVActivityIndicatorAnimationBallPulseRise()
-        case .BallRotate:
-            return NVActivityIndicatorAnimationBallRotate()
-        case .CubeTransition:
-            return NVActivityIndicatorAnimationCubeTransition()
-        case .BallZigZag:
-            return NVActivityIndicatorAnimationBallZigZag()
-        case .BallZigZagDeflect:
-            return NVActivityIndicatorAnimationBallZigZagDeflect()
-        case .BallTrianglePath:
-            return NVActivityIndicatorAnimationBallTrianglePath()
-        case .BallScale:
-            return NVActivityIndicatorAnimationBallScale()
-        case .LineScale:
-            return NVActivityIndicatorAnimationLineScale()
-        case .LineScaleParty:
-            return NVActivityIndicatorAnimationLineScaleParty()
-        case .BallScaleMultiple:
-            return NVActivityIndicatorAnimationBallScaleMultiple()
-        case .BallPulseSync:
-            return NVActivityIndicatorAnimationBallPulseSync()
-        case .BallBeat:
-            return NVActivityIndicatorAnimationBallBeat()
-        case .LineScalePulseOut:
-            return NVActivityIndicatorAnimationLineScalePulseOut()
-        case .LineScalePulseOutRapid:
-            return NVActivityIndicatorAnimationLineScalePulseOutRapid()
-        case .BallScaleRipple:
-            return NVActivityIndicatorAnimationBallScaleRipple()
-        case .BallScaleRippleMultiple:
-            return NVActivityIndicatorAnimationBallScaleRippleMultiple()
-        case .BallSpinFadeLoader:
-            return NVActivityIndicatorAnimationBallSpinFadeLoader()
-        case .LineSpinFadeLoader:
-            return NVActivityIndicatorAnimationLineSpinFadeLoader()
-        case .TriangleSkewSpin:
-            return NVActivityIndicatorAnimationTriangleSkewSpin()
-        case .Pacman:
-            return NVActivityIndicatorAnimationPacman()
-        case .BallGridBeat:
-            return NVActivityIndicatorAnimationBallGridBeat()
-        case .SemiCircleSpin:
-            return NVActivityIndicatorAnimationSemiCircleSpin()
-        }
     }
 }

--- a/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -41,9 +41,9 @@ public enum NVActivityIndicatorType {
 }
 
 public class NVActivityIndicatorView: UIView {
-    private let DEFAULT_TYPE: NVActivityIndicatorType = .Pacman
-    private let DEFAULT_COLOR = UIColor.whiteColor()
-    private let DEFAULT_SIZE: CGSize = CGSize(width: 40, height: 40)
+    private static let DEFAULT_TYPE: NVActivityIndicatorType = .Pacman
+    private static let DEFAULT_COLOR = UIColor.whiteColor()
+    private static let DEFAULT_SIZE: CGSize = CGSize(width: 40, height: 40)
     
     private var type: NVActivityIndicatorType
     private var color: UIColor
@@ -65,9 +65,9 @@ public class NVActivityIndicatorView: UIView {
         :returns: The activity indicator view
     */
     required public init(coder aDecoder: NSCoder) {
-        self.type = DEFAULT_TYPE
-        self.color = DEFAULT_COLOR
-        self.size = DEFAULT_SIZE
+        self.type = NVActivityIndicatorView.DEFAULT_TYPE
+        self.color = NVActivityIndicatorView.DEFAULT_COLOR
+        self.size = NVActivityIndicatorView.DEFAULT_SIZE
         super.init(coder: aDecoder);
     }
     
@@ -75,54 +75,17 @@ public class NVActivityIndicatorView: UIView {
         Create a activity indicator view with specified type, color, size and size
         
         :param: frame view's frame
-        :param: type animation type, value of NVActivityIndicatorType enum
-        :param: color color of activity indicator view
-        :param: size actual size of animation in view
+        :param: type animation type, value of NVActivityIndicatorType enum. Default type is pacman.
+        :param: color color of activity indicator view. Default color is white.
+        :param: size actual size of animation in view. Default size is 40
     
         :returns: The activity indicator view
     */
-    public init(frame: CGRect, type: NVActivityIndicatorType, color: UIColor?, size: CGSize?) {
+    public init(frame: CGRect, type: NVActivityIndicatorType = DEFAULT_TYPE, color: UIColor = DEFAULT_COLOR, size: CGSize = DEFAULT_SIZE) {
         self.type = type
-        self.color = DEFAULT_COLOR
-        self.size = DEFAULT_SIZE
+        self.color = color
+        self.size = size
         super.init(frame: frame)
-        
-        if let _color = color {
-            self.color = _color
-        }
-        if let _size = size {
-            self.size = _size
-        }
-    }
-    
-    /**
-        Create a activity indicator view with specified type, color and default size
-    
-        - Default size is 40
-        
-        :param: frame view's frame
-        :param: value animation type, value of NVActivityIndicatorType enum
-        :param: color color of activity indicator view
-    
-        :returns: The activity indicator view
-    */
-    convenience public init(frame: CGRect, type: NVActivityIndicatorType, color: UIColor?) {
-        self.init(frame: frame, type: type, color: color, size: nil)
-    }
-    
-    /**
-        Create a activity indicator view with specified type and default color, size
-    
-        - Default color is white
-        - Default size is 40
-    
-        :param: view view's frame
-        :param: value animation type, value of NVActivityIndicatorType enum
-    
-        :returns: The activity indicator view
-    */
-    convenience public init(frame: CGRect, type: NVActivityIndicatorType) {
-        self.init(frame: frame, type: type, color: nil)
     }
     
     /**

--- a/README.md
+++ b/README.md
@@ -49,28 +49,55 @@ Firstly, import NVActivityIndicatorView
 import NVActivityIndicatorView
 ```
 
-Then, there are 4 ways you can do:
+Then, there are multiple ways you can create NVActivityIndicatorView:
 
 - Use it in storyboard by changing class of any `UIView` to `NVActivityIndicatorView`
 This will use default values 40, white, .Pacman for size, color and type respectively.
 
-- Create with specified type and size 40, color white as default
-
-```swift
-NVActivityIndicatorView(frame: frame, type: type)
-```
-
-- Create with specified type, color and size 40 as default
-
-```swift
-NVActivityIndicatorView(frame: frame, type: type, color: color)
-```
-
-- Create with specified type, color, size
+- Create with specified type, color and size
 
 ```swift
 NVActivityIndicatorView(frame: frame, type: type, color: color, size: size)
 ```
+
+Any of the last three arguments can be omitted. If an argument is omitted it will use the defailt values which are 40, white, .Pacman for size, color and type respectively.
+Therefore, you can also create NVActivityIndicatorView using any of the following:
+
+- specify only frame, type and color
+```swift
+NVActivityIndicatorView(frame: frame, type: type, color: color)
+```
+
+- specify only frame, type and size
+```swift
+NVActivityIndicatorView(frame: frame, type: type, size: size)
+```
+
+- specify only frame, size and color
+```swift
+NVActivityIndicatorView(frame: frame, size: size, color: color)
+```
+
+- specify only frame and type
+```swift
+NVActivityIndicatorView(frame: frame, type: type)
+```
+
+- specify only frame and color
+```swift
+NVActivityIndicatorView(frame: frame, color: color)
+```
+
+- specify only frame and size
+```swift
+NVActivityIndicatorView(frame: frame, size: size)
+```
+
+- specify only frame
+```swift
+NVActivityIndicatorView(frame: frame)
+```
+
 # Acknowledgment
 
 Thanks [Connor Atherton](https://github.com/ConnorAtherton) for great loaders and [Danil Gontovnik](https://github.com/gontovnik) for kick-start.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This will use default values 40, white, .Pacman for size, color and type respect
 NVActivityIndicatorView(frame: frame, type: type, color: color, size: size)
 ```
 
-Any of the last three arguments can be omitted. If an argument is omitted it will use the defailt values which are 40, white, .Pacman for size, color and type respectively.
+Any of the last three arguments can be omitted. If an argument is omitted it will use the default values which are 40, white, .Pacman for size, color and type respectively.
 Therefore, you can also create NVActivityIndicatorView using any of the following:
 
 - specify only frame, type and color


### PR DESCRIPTION
I did some refactoring:
- use parameters with default values instead of optionals. This way the two convenience constructor that use nil to indicate absent optional values can be safely removed. Also size and color can be directly assigned since there is no optionals involved.
- the method that maps the indicator type to the delegate can be moved to the enum itself. The delegate can be then accessed directly from the enum value 
