### PR TITLE
clear color of view to see animation instead of white space

### DIFF
--- a/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -132,6 +132,7 @@ public class NVActivityIndicatorView: UIView {
         self.color = NVActivityIndicatorView.DEFAULT_COLOR
         self.size = NVActivityIndicatorView.DEFAULT_SIZE
         super.init(coder: aDecoder);
+        super.backgroundColor = UIColor.clearColor()
     }
     
     /**


### PR DESCRIPTION
This seems to be included to the swift 2.0 branch but not in the 1.2 version. So I added it.
