### PR TITLE
Added feature to support delays when showing the loading activity.

### DIFF
--- a/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
@@ -1,0 +1,120 @@
+//
+//  NVActivityIndicatorPresenter.swift
+//  NVActivityIndicatorViewDemo
+//
+//  Created by Diego Ernst on 8/31/16.
+//  Copyright © 2016 Nguyen Vinh. All rights reserved.
+//
+
+import UIKit
+
+class ActivityData {
+
+    let size: CGSize?
+    let message: String?
+    let type: NVActivityIndicatorType?
+    let color: UIColor?
+    let padding: CGFloat?
+    let minimumVisibleTime: NSTimeInterval
+    let displayTimeThreshold: NSTimeInterval
+
+    init(size: CGSize?, message: String?, type: NVActivityIndicatorType?, color: UIColor?, padding: CGFloat?, minimumVisibleTime: NSTimeInterval, displayTimeThreshold: NSTimeInterval) {
+        self.size = size
+        self.message = message
+        self.type = type
+        self.color = color
+        self.padding = padding
+        self.minimumVisibleTime = minimumVisibleTime
+        self.displayTimeThreshold = displayTimeThreshold
+    }
+
+}
+
+class NVActivityIndicatorPresenter {
+
+    static let sharedInstance = NVActivityIndicatorPresenter()
+
+    private var showActivityTimer: NSTimer?
+    private var hideActivityTimer: NSTimer?
+    private var userWantsToStopActivity = false
+    private let activityRestorationIdentifier = "NVActivityIndicatorViewContainer"
+
+    private init() { }
+
+    func startActivityAnimating(data: ActivityData) {
+        guard showActivityTimer == nil else { return }
+        userWantsToStopActivity = false
+        showActivityTimer = scheduleTimer(data.displayTimeThreshold, selector: #selector(NVActivityIndicatorPresenter.showActivityTimerFired(_:)), data: data)
+    }
+
+    func stopActivityAnimating() {
+        userWantsToStopActivity = true
+        guard hideActivityTimer == nil else { return }
+        hideActivity()
+    }
+
+    // MARK: - Timer events
+
+    @objc func hideActivityTimerFired(timer: NSTimer) {
+        hideActivityTimer?.invalidate()
+        hideActivityTimer = nil
+        if userWantsToStopActivity {
+            hideActivity()
+        }
+    }
+
+    @objc func showActivityTimerFired(timer: NSTimer) {
+        guard let activityData = timer.userInfo as? ActivityData else { return }
+        showActivity(activityData)
+    }
+
+    // MARK: - Helpers
+
+    private func showActivity(activityData: ActivityData) {
+        let activityContainer: UIView = UIView(frame: UIScreen.mainScreen().bounds)
+        
+        activityContainer.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+        activityContainer.restorationIdentifier = activityRestorationIdentifier
+        
+        let actualSize = activityData.size ?? NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE
+        let activityIndicatorView = NVActivityIndicatorView(
+            frame: CGRectMake(0, 0, actualSize.width, actualSize.height),
+            type: activityData.type,
+            color: activityData.color,
+            padding: activityData.padding)
+        
+        activityIndicatorView.center = activityContainer.center
+        activityIndicatorView.startAnimating()
+        activityContainer.addSubview(activityIndicatorView)
+        
+        let width = activityContainer.frame.size.width / 3
+        if let message = activityData.message where !message.isEmpty {
+            let label = UILabel(frame: CGRectMake(0, 0, width, 30))
+            label.center = CGPointMake(
+                activityIndicatorView.center.x,
+                activityIndicatorView.center.y + actualSize.height)
+            label.textAlignment = .Center
+            label.text = message
+            label.font = UIFont.boldSystemFontOfSize(20)
+            label.textColor = activityIndicatorView.color
+            activityContainer.addSubview(label)
+        }
+
+        hideActivityTimer = scheduleTimer(activityData.minimumVisibleTime, selector: #selector(NVActivityIndicatorPresenter.hideActivityTimerFired(_:)), data: nil)
+        UIApplication.sharedApplication().keyWindow!.addSubview(activityContainer)
+    }
+
+    private func hideActivity() {
+        for item in UIApplication.sharedApplication().keyWindow!.subviews
+            where item.restorationIdentifier == activityRestorationIdentifier {
+                item.removeFromSuperview()
+        }
+        showActivityTimer?.invalidate()
+        showActivityTimer = nil
+    }
+
+    private func scheduleTimer(timeInterval: NSTimeInterval, selector: Selector, data: ActivityData?) -> NSTimer {
+        return NSTimer.scheduledTimerWithTimeInterval(timeInterval, target: self, selector: selector, userInfo: data, repeats: false)
+    }
+
+}

--- a/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -323,6 +323,12 @@ public class NVActivityIndicatorView: UIView {
     /// Default size of activity indicator view in UI blocker. Default value is 60x60.
     public static var DEFAULT_BLOCKER_SIZE = CGSizeMake(60, 60)
     
+    /// Default minimum visible time of activity indicator view in UI blocker. Default value is 0 ms.
+    public static var DEFAULT_BLOCKER_MINIMUM_VISIBLE_TIME = NSTimeInterval(0)
+
+    /// Minimum time that has to be elapsed in order to actually display the activity indicator view. Default is 0 ms.
+    public static var DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD = NSTimeInterval(0)
+
     /// Animation type, value of NVActivityIndicatorType enum.
     public var type: NVActivityIndicatorType = NVActivityIndicatorView.DEFAULT_TYPE
 

--- a/NVActivityIndicatorView/NVActivityIndicatorViewable.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorViewable.swift
@@ -17,10 +17,6 @@ public protocol NVActivityIndicatorViewable { }
 
 public extension NVActivityIndicatorViewable where Self: UIViewController {
 
-    private var activityRestorationIdentifier: String {
-        return "NVActivityIndicatorViewContainer"
-    }
-
     /**
      Create a activity indicator view with specified frame, type, color and padding and start animation.
      
@@ -29,48 +25,36 @@ public extension NVActivityIndicatorViewable where Self: UIViewController {
      - parameter type: animation type, value of NVActivityIndicatorType enum. Default type is BallSpinFadeLoader.
      - parameter color: color of activity indicator view. Default color is white.
      - parameter padding: view's padding. Default padding is 0.
+     - parameter minimumVisibleTime: minimum visible time of activity indicator view in UI blocker. Default value is 0 ms.
+     - parameter displayTimeThreshold: minimum time that has to be elapsed in order to actually display the activity indicator view. Default is 0 ms.
      */
-    public func startActivityAnimating(size: CGSize? = nil, message: String? = nil, type: NVActivityIndicatorType? = nil, color: UIColor? = nil, padding: CGFloat? = nil) {
-        let activityContainer: UIView = UIView(frame: UIScreen.mainScreen().bounds)
-        
-        activityContainer.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
-        activityContainer.restorationIdentifier = activityRestorationIdentifier
-        
-        let actualSize = size ?? NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE
-        let activityIndicatorView = NVActivityIndicatorView(
-            frame: CGRectMake(0, 0, actualSize.width, actualSize.height),
+    public func startActivityAnimating(
+        size: CGSize? = nil,
+        message: String? = nil,
+        type: NVActivityIndicatorType? = nil,
+        color: UIColor? = nil,
+        padding: CGFloat? = nil,
+        minimumVisibleTime: NSTimeInterval = NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_VISIBLE_TIME,
+        displayTimeThreshold: NSTimeInterval = NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD) {
+
+        let data = ActivityData(
+            size: size,
+            message: message,
             type: type,
             color: color,
-            padding: padding)
-        
-        activityIndicatorView.center = activityContainer.center
-        activityIndicatorView.startAnimating()
-        activityContainer.addSubview(activityIndicatorView)
-        
-        let width = activityContainer.frame.size.width / 3
-        if let message = message where !message.isEmpty {
-            let label = UILabel(frame: CGRectMake(0, 0, width, 30))
-            label.center = CGPointMake(
-                activityIndicatorView.center.x,
-                activityIndicatorView.center.y + actualSize.height)
-            label.textAlignment = .Center
-            label.text = message
-            label.font = UIFont.boldSystemFontOfSize(20)
-            label.textColor = activityIndicatorView.color
-            activityContainer.addSubview(label)
-        }
-        
-        UIApplication.sharedApplication().keyWindow!.addSubview(activityContainer)
+            padding: padding,
+            minimumVisibleTime: minimumVisibleTime,
+            displayTimeThreshold: displayTimeThreshold
+        )
+
+        NVActivityIndicatorPresenter.sharedInstance.startActivityAnimating(data)
     }
-    
+
     /**
      Stop animation and remove from view hierarchy.
      */
     public func stopActivityAnimating() {
-        for item in UIApplication.sharedApplication().keyWindow!.subviews
-            where item.restorationIdentifier == activityRestorationIdentifier {
-                item.removeFromSuperview()
-        }
+        NVActivityIndicatorPresenter.sharedInstance.stopActivityAnimating()
     }
-    
+
 }

--- a/NVActivityIndicatorViewDemo.xcodeproj/project.pbxproj
+++ b/NVActivityIndicatorViewDemo.xcodeproj/project.pbxproj
@@ -14,11 +14,11 @@
 		239CAB301B5EBB2E0051DC06 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 239CAB2E1B5EBB2E0051DC06 /* LaunchScreen.xib */; };
 		23B201041D7DADBF00130679 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239CAB251B5EBB2E0051DC06 /* AppDelegate.swift */; };
 		23B201051D7DADBF00130679 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239CAB271B5EBB2E0051DC06 /* ViewController.swift */; };
-		23B201061D7DADBF00130679 /* ViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2315A51A1D7BF6C600C3305F /* ViewController2.swift */; };
 		23B201071D7DADCD00130679 /* NVActivityIndicatorView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A8792F1BA554A0001C8989 /* NVActivityIndicatorView.framework */; };
 		23B6C6051D7AD28500C90328 /* NVActivityIndicatorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B6C6041D7AD28500C90328 /* NVActivityIndicatorTypeTests.swift */; };
 		23FB13521D76D5370096EBE3 /* NVActivityIndicatorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FB13511D76D5370096EBE3 /* NVActivityIndicatorViewTests.swift */; };
 		23FB13541D76D5370096EBE3 /* NVActivityIndicatorView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A8792F1BA554A0001C8989 /* NVActivityIndicatorView.framework */; };
+		46361A7E1D775B7100E4DB4D /* NVActivityIndicatorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46361A7D1D775B7100E4DB4D /* NVActivityIndicatorPresenter.swift */; };
 		8B1EEC821CF723E100AE054B /* NVActivityIndicatorViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1EEC811CF723E100AE054B /* NVActivityIndicatorViewable.swift */; };
 		90A879341BA554A0001C8989 /* NVActivityIndicatorView.h in Headers */ = {isa = PBXBuildFile; fileRef = 90A879331BA554A0001C8989 /* NVActivityIndicatorView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90A879891BA55798001C8989 /* NVActivityIndicatorAnimationBallBeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A879691BA55798001C8989 /* NVActivityIndicatorAnimationBallBeat.swift */; };
@@ -68,7 +68,6 @@
 
 /* Begin PBXFileReference section */
 		230C6FA71D0FE9E5007CD4E4 /* NVActivityIndicatorAnimationAudioEqualizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NVActivityIndicatorAnimationAudioEqualizer.swift; sourceTree = "<group>"; };
-		2315A51A1D7BF6C600C3305F /* ViewController2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController2.swift; sourceTree = "<group>"; };
 		233236801D0D80C9001F4703 /* NVActivityIndicatorAnimationOrbit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NVActivityIndicatorAnimationOrbit.swift; sourceTree = "<group>"; };
 		239CAB201B5EBB2E0051DC06 /* NVActivityIndicatorViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NVActivityIndicatorViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		239CAB241B5EBB2E0051DC06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -81,6 +80,7 @@
 		23FB134F1D76D5370096EBE3 /* NVActivityIndicatorViewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NVActivityIndicatorViewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		23FB13511D76D5370096EBE3 /* NVActivityIndicatorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NVActivityIndicatorViewTests.swift; sourceTree = "<group>"; };
 		23FB13531D76D5370096EBE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		46361A7D1D775B7100E4DB4D /* NVActivityIndicatorPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NVActivityIndicatorPresenter.swift; sourceTree = "<group>"; };
 		8B1EEC811CF723E100AE054B /* NVActivityIndicatorViewable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NVActivityIndicatorViewable.swift; sourceTree = "<group>"; };
 		90A8792F1BA554A0001C8989 /* NVActivityIndicatorView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NVActivityIndicatorView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		90A879321BA554A0001C8989 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -176,7 +176,6 @@
 				239CAB2C1B5EBB2E0051DC06 /* Images.xcassets */,
 				239CAB2E1B5EBB2E0051DC06 /* LaunchScreen.xib */,
 				239CAB231B5EBB2E0051DC06 /* Supporting Files */,
-				2315A51A1D7BF6C600C3305F /* ViewController2.swift */,
 			);
 			path = NVActivityIndicatorViewDemo;
 			sourceTree = "<group>";
@@ -206,6 +205,7 @@
 				90A879861BA55798001C8989 /* NVActivityIndicatorAnimationDelegate.swift */,
 				90A879871BA55798001C8989 /* NVActivityIndicatorShape.swift */,
 				8B1EEC811CF723E100AE054B /* NVActivityIndicatorViewable.swift */,
+				46361A7D1D775B7100E4DB4D /* NVActivityIndicatorPresenter.swift */,
 				90A879881BA55798001C8989 /* NVActivityIndicatorView.swift */,
 				90A879331BA554A0001C8989 /* NVActivityIndicatorView.h */,
 				90A879311BA554A0001C8989 /* Supporting Files */,
@@ -403,7 +403,6 @@
 			files = (
 				23B201041D7DADBF00130679 /* AppDelegate.swift in Sources */,
 				23B201051D7DADBF00130679 /* ViewController.swift in Sources */,
-				23B201061D7DADBF00130679 /* ViewController2.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -442,6 +441,7 @@
 				90A879A51BA55798001C8989 /* NVActivityIndicatorAnimationTriangleSkewSpin.swift in Sources */,
 				90A879921BA55798001C8989 /* NVActivityIndicatorAnimationBallRotate.swift in Sources */,
 				BD1452341C15810200B952C8 /* NVActivityIndicatorAnimationBallRotateChase.swift in Sources */,
+				46361A7E1D775B7100E4DB4D /* NVActivityIndicatorPresenter.swift in Sources */,
 				90A879941BA55798001C8989 /* NVActivityIndicatorAnimationBallScaleMultiple.swift in Sources */,
 				90A879A11BA55798001C8989 /* NVActivityIndicatorAnimationLineSpinFadeLoader.swift in Sources */,
 				90A879981BA55798001C8989 /* NVActivityIndicatorAnimationBallTrianglePath.swift in Sources */,

--- a/NVActivityIndicatorViewTests/NVActivityIndicatorViewTests.swift
+++ b/NVActivityIndicatorViewTests/NVActivityIndicatorViewTests.swift
@@ -29,6 +29,8 @@ class NVActivityIndicatorViewTests: XCTestCase {
         XCTAssertEqual(NVActivityIndicatorView.DEFAULT_COLOR, UIColor.whiteColor())
         XCTAssertEqual(NVActivityIndicatorView.DEFAULT_PADDING, 0)
         XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE, CGSize(width: 60, height: 60))
+        XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_VISIBLE_TIME, NSTimeInterval(0))
+        XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD, NSTimeInterval(0))
     }
     
     func testSetTypeName() {

--- a/README.md
+++ b/README.md
@@ -221,12 +221,30 @@ animation = activityIndicatorView.animating
 
 Change global defaults if needed
 
-```swift
-NVActivityIndicatorView.DEFAULT_TYPE = .Pacman
-NVActivityIndicatorView.DEFAULT_COLOR = UIColor.yellowColor()
-NVActivityIndicatorView.DEFAULT_PADDING = CGFloat(5.0)
-NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE = CGSizeMake(60, 60)
-```
+###### `NVActivityIndicatorView.DEFAULT_TYPE = .Pacman`
+
+Default type of activity indicator.
+
+###### `NVActivityIndicatorView.DEFAULT_COLOR = UIColor.yellowColor()`
+
+Default color of activity indicator.
+
+###### `NVActivityIndicatorView.DEFAULT_PADDING = CGFloat(5.0)`
+
+Default padding of activity indicator.
+
+###### `NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE = CGSizeMake(60, 60)`
+
+Default size of activity indicator used in UI Blocker.
+
+###### `NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_VISIBLE_TIME = NSTimeInterval(0)`
+
+Default minimum visible time of an activity indicator view in UI Blocker. Its main purpose is to avoid flashes showing and hiding it so fast. For instance, setting it to 200 ms will force every activity indicator to be shown for at least this time (regardless if you call `stopActivityAnimating` before).
+
+###### `NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD = NSTimeInterval(0)`
+
+Default minimum time that has to be elapsed (between calls of `startActivityAnimating` and `stopActivityAnimating`) in order to actually display the activity indicator view in UI Blocker. It should be set thinking about what the minimum duration of an activity is to be worth showing it to the user. If the activity ends before this time threshold, then it will not be displayed at all.
+
 
 # Acknowledgment
 


### PR DESCRIPTION
- Added a default minimum visible time of activity indicator view in UI blocker. Default is 0 ms.(`NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_VISIBLE_TIME`)
- Added a default minimum time that has to be elapsed in order to actually display the activity indicator view. Default is 0 ms.
  (`NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD`)

Those parameters can also be specified at the `startActivityAnimating`and `stopActivityAnimating` function calls in order to override the default ones.
