### PR TITLE
Allow the UI blocker background color to be customized via ActivityData

### DIFF
--- a/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
@@ -53,6 +53,9 @@ public final class ActivityData {
     /// Minimum display time of UI blocker.
     let minimumDisplayTime: Int
     
+    /// Background color of the UI blocker
+    let backgroundColor: UIColor
+    
     /**
      Create information package used to display UI blocker.
      
@@ -76,7 +79,8 @@ public final class ActivityData {
                 color: UIColor? = nil,
                 padding: CGFloat? = nil,
                 displayTimeThreshold: Int? = nil,
-                minimumDisplayTime: Int? = nil) {
+                minimumDisplayTime: Int? = nil,
+                backgroundColor: UIColor? = nil) {
         self.size = size ?? NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE
         self.message = message ?? NVActivityIndicatorView.DEFAULT_BLOCKER_MESSAGE
         self.messageFont = messageFont ?? NVActivityIndicatorView.DEFAULT_BLOCKER_MESSAGE_FONT
@@ -85,6 +89,7 @@ public final class ActivityData {
         self.padding = padding ?? NVActivityIndicatorView.DEFAULT_PADDING
         self.displayTimeThreshold = displayTimeThreshold ?? NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD
         self.minimumDisplayTime = minimumDisplayTime ?? NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_DISPLAY_TIME
+        self.backgroundColor = backgroundColor ?? NVActivityIndicatorView.DEFAULT_BLOCKER_BACKGROUND_COLOR
     }
 }
 
@@ -143,7 +148,7 @@ public final class NVActivityIndicatorPresenter {
     private func show(with activityData: ActivityData) {
         let activityContainer: UIView = UIView(frame: UIScreen.main.bounds)
         
-        activityContainer.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+        activityContainer.backgroundColor = activityData.backgroundColor
         activityContainer.restorationIdentifier = restorationIdentifier
         
         let actualSize = activityData.size

--- a/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -355,6 +355,9 @@ public final class NVActivityIndicatorView: UIView {
     /// Default font of message displayed in UI blocker. Default value is bold system font, size 20.
     public static var DEFAULT_BLOCKER_MESSAGE_FONT = UIFont.boldSystemFont(ofSize: 20)
     
+    /// Default background color of UI blocker. Default value is UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+    public static var DEFAULT_BLOCKER_BACKGROUND_COLOR = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
+    
     /// Animation type.
     public var type: NVActivityIndicatorType = NVActivityIndicatorView.DEFAULT_TYPE
     

--- a/NVActivityIndicatorView/NVActivityIndicatorViewable.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorViewable.swift
@@ -58,7 +58,8 @@ public extension NVActivityIndicatorViewable where Self: UIViewController {
         color: UIColor? = nil,
         padding: CGFloat? = nil,
         displayTimeThreshold: Int? = nil,
-        minimumDisplayTime: Int? = nil) {
+        minimumDisplayTime: Int? = nil,
+        backgroundColor: UIColor? = nil) {
         let activityData = ActivityData(size: size,
                                         message: message,
                                         messageFont: messageFont,
@@ -66,7 +67,8 @@ public extension NVActivityIndicatorViewable where Self: UIViewController {
                                         color: color,
                                         padding: padding,
                                         displayTimeThreshold: displayTimeThreshold,
-                                        minimumDisplayTime: minimumDisplayTime)
+                                        minimumDisplayTime: minimumDisplayTime,
+                                        backgroundColor: backgroundColor)
         
         NVActivityIndicatorPresenter.sharedInstance.startAnimating(activityData)
     }

--- a/NVActivityIndicatorViewTests/ActivityDataTests.swift
+++ b/NVActivityIndicatorViewTests/ActivityDataTests.swift
@@ -40,6 +40,7 @@ class ActivityDataTests: XCTestCase {
         XCTAssertEqual(activityData.padding, NVActivityIndicatorView.DEFAULT_PADDING)
         XCTAssertEqual(activityData.displayTimeThreshold, NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD)
         XCTAssertEqual(activityData.minimumDisplayTime, NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_DISPLAY_TIME)
+        XCTAssertEqual(activityData.backgroundColor, NVActivityIndicatorView.DEFAULT_BLOCKER_BACKGROUND_COLOR)
     }
     
     func testInitWithParams() {
@@ -50,13 +51,15 @@ class ActivityDataTests: XCTestCase {
         let padding: CGFloat = 10
         let displayTimeThreshold = 100
         let minimumDisplayTime = 150
+        let backgroundColor = UIColor.red
         let activityData = ActivityData(size: size,
                                         message: message,
                                         type: type,
                                         color: color,
                                         padding: padding,
                                         displayTimeThreshold: displayTimeThreshold,
-                                        minimumDisplayTime: minimumDisplayTime)
+                                        minimumDisplayTime: minimumDisplayTime,
+                                        backgroundColor: backgroundColor)
         
         XCTAssertEqual(activityData.size, size)
         XCTAssertEqual(activityData.message, message)
@@ -65,5 +68,6 @@ class ActivityDataTests: XCTestCase {
         XCTAssertEqual(activityData.padding, padding)
         XCTAssertEqual(activityData.displayTimeThreshold, displayTimeThreshold)
         XCTAssertEqual(activityData.minimumDisplayTime, minimumDisplayTime)
+        XCTAssertEqual(activityData.backgroundColor, backgroundColor)
     }
 }

--- a/NVActivityIndicatorViewTests/NVActivityIndicatorViewTests.swift
+++ b/NVActivityIndicatorViewTests/NVActivityIndicatorViewTests.swift
@@ -50,6 +50,7 @@ class NVActivityIndicatorViewTests: XCTestCase {
         XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE, CGSize(width: 60, height: 60))
         XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_DISPLAY_TIME, 0)
         XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD, 0)
+        XCTAssertEqual(NVActivityIndicatorView.DEFAULT_BLOCKER_BACKGROUND_COLOR, UIColor(red: 0, green: 0, blue: 0, alpha: 0.5))
     }
     
     func testSetTypeName() {

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ NVActivityIndicatorView.DEFAULT_TYPE = .BallSpinFadeLoader
 - Default color of activity indicator view.
 
 ```swift
-NVActivityIndicatorView.DEFAULT_COLOR = UIColor.whiteColor()
+NVActivityIndicatorView.DEFAULT_COLOR = UIColor.white
 ```
 
 - Default padding of activity indicator view.
@@ -212,6 +212,12 @@ NVActivityIndicatorView.DEFAULT_PADDING = CGFloat(0)
 
 ```swift
 NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE = CGSizeMake(60, 60)
+```
+
+- Default background color of UI blocker.
+
+```swift
+NVActivityIndicatorView.DEFAULT_BLOCKER_BACKGROUND_COLOR = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5)
 ```
 
 - Default display time threshold.


### PR DESCRIPTION
This change addresses the request in #96 
Allow the background color of the UI blocker to optionally be set. If not set it will continue to be the previous color (Black - 0.5 alpha).
Customization of the UI blocker background color is done via an additional optional parameter of ActivityData.