### PR TITLE
Allow the activity text color to be set separately from the activity indicator color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ xcuserdata/
 ## Other
 *.moved-aside
 *.xcuserstate
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap

--- a/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
@@ -44,6 +44,9 @@ public final class ActivityData {
     /// Color of activity indicator view.
     let color: UIColor
     
+    /// Color of text.
+    let textColor: UIColor
+    
     /// Padding of activity indicator view.
     let padding: CGFloat
     
@@ -69,6 +72,7 @@ public final class ActivityData {
      - parameter padding:              padding of activity indicator view.
      - parameter displayTimeThreshold: display time threshold to actually display UI blocker.
      - parameter minimumDisplayTime:   minimum display time of UI blocker.
+     - parameter textColor:            color of the text below the activity indicator view. Will match color parameter if not set, otherwise DEFAULT_TEXT_COLOR if color is not set.
      
      - returns: The information package used to display UI blocker.
      */
@@ -80,7 +84,8 @@ public final class ActivityData {
                 padding: CGFloat? = nil,
                 displayTimeThreshold: Int? = nil,
                 minimumDisplayTime: Int? = nil,
-                backgroundColor: UIColor? = nil) {
+                backgroundColor: UIColor? = nil,
+                textColor: UIColor? = nil) {
         self.size = size ?? NVActivityIndicatorView.DEFAULT_BLOCKER_SIZE
         self.message = message ?? NVActivityIndicatorView.DEFAULT_BLOCKER_MESSAGE
         self.messageFont = messageFont ?? NVActivityIndicatorView.DEFAULT_BLOCKER_MESSAGE_FONT
@@ -90,6 +95,7 @@ public final class ActivityData {
         self.displayTimeThreshold = displayTimeThreshold ?? NVActivityIndicatorView.DEFAULT_BLOCKER_DISPLAY_TIME_THRESHOLD
         self.minimumDisplayTime = minimumDisplayTime ?? NVActivityIndicatorView.DEFAULT_BLOCKER_MINIMUM_DISPLAY_TIME
         self.backgroundColor = backgroundColor ?? NVActivityIndicatorView.DEFAULT_BLOCKER_BACKGROUND_COLOR
+        self.textColor = textColor ?? color ?? NVActivityIndicatorView.DEFAULT_TEXT_COLOR
     }
 }
 
@@ -195,7 +201,7 @@ public final class NVActivityIndicatorPresenter {
         activityContainer.addSubview(activityIndicatorView)
 
         activityLabel.font = activityData.messageFont
-        activityLabel.textColor = activityIndicatorView.color
+        activityLabel.textColor = activityData.textColor
         setMessage(activityData.message)
         activityContainer.addSubview(activityLabel)
       

--- a/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -334,8 +334,11 @@ public final class NVActivityIndicatorView: UIView {
     /// Default type. Default value is .BallSpinFadeLoader.
     public static var DEFAULT_TYPE: NVActivityIndicatorType = .ballSpinFadeLoader
     
-    /// Default color. Default value is UIColor.whiteColor().
+    /// Default color of activity indicator. Default value is UIColor.white.
     public static var DEFAULT_COLOR = UIColor.white
+    
+    /// Default color of text. Default value is UIColor.white.
+    public static var DEFAULT_TEXT_COLOR = UIColor.white
     
     /// Default padding. Default value is 0.
     public static var DEFAULT_PADDING: CGFloat = 0

--- a/NVActivityIndicatorView/NVActivityIndicatorViewable.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorViewable.swift
@@ -59,7 +59,8 @@ public extension NVActivityIndicatorViewable where Self: UIViewController {
         padding: CGFloat? = nil,
         displayTimeThreshold: Int? = nil,
         minimumDisplayTime: Int? = nil,
-        backgroundColor: UIColor? = nil) {
+        backgroundColor: UIColor? = nil,
+        textColor: UIColor? = nil) {
         let activityData = ActivityData(size: size,
                                         message: message,
                                         messageFont: messageFont,
@@ -68,7 +69,8 @@ public extension NVActivityIndicatorViewable where Self: UIViewController {
                                         padding: padding,
                                         displayTimeThreshold: displayTimeThreshold,
                                         minimumDisplayTime: minimumDisplayTime,
-                                        backgroundColor: backgroundColor)
+                                        backgroundColor: backgroundColor,
+                                        textColor: textColor)
         
         NVActivityIndicatorPresenter.sharedInstance.startAnimating(activityData)
     }

--- a/NVActivityIndicatorViewTests/ActivityDataTests.swift
+++ b/NVActivityIndicatorViewTests/ActivityDataTests.swift
@@ -44,6 +44,7 @@ class ActivityDataTests: XCTestCase {
     }
     
     func testInitWithParams() {
+        
         let size = CGSize(width: 100, height: 100)
         let message = "Loading..."
         let type = NVActivityIndicatorType.ballBeat
@@ -52,6 +53,7 @@ class ActivityDataTests: XCTestCase {
         let displayTimeThreshold = 100
         let minimumDisplayTime = 150
         let backgroundColor = UIColor.red
+        let textColor = UIColor.purple
         let activityData = ActivityData(size: size,
                                         message: message,
                                         type: type,
@@ -59,7 +61,8 @@ class ActivityDataTests: XCTestCase {
                                         padding: padding,
                                         displayTimeThreshold: displayTimeThreshold,
                                         minimumDisplayTime: minimumDisplayTime,
-                                        backgroundColor: backgroundColor)
+                                        backgroundColor: backgroundColor,
+                                        textColor: textColor)
         
         XCTAssertEqual(activityData.size, size)
         XCTAssertEqual(activityData.message, message)
@@ -69,5 +72,22 @@ class ActivityDataTests: XCTestCase {
         XCTAssertEqual(activityData.displayTimeThreshold, displayTimeThreshold)
         XCTAssertEqual(activityData.minimumDisplayTime, minimumDisplayTime)
         XCTAssertEqual(activityData.backgroundColor, backgroundColor)
+        XCTAssertEqual(activityData.textColor, textColor)
+    }
+    
+    func testTextColorInitWithColor() {
+        
+        let color = UIColor.red
+        let activityData = ActivityData(color: color)
+        
+        XCTAssertEqual(activityData.color, color)
+        XCTAssertEqual(activityData.textColor, color) // textColor matches color
+    }
+    
+    func testNoColorOrTextColorInit() {
+        
+        let activityData = ActivityData()
+        
+        XCTAssertEqual(activityData.textColor, NVActivityIndicatorView.DEFAULT_TEXT_COLOR)
     }
 }

--- a/NVActivityIndicatorViewTests/NVActivityIndicatorPresenterTests.swift
+++ b/NVActivityIndicatorViewTests/NVActivityIndicatorPresenterTests.swift
@@ -105,7 +105,8 @@ class NVActivityIndicatorPresenterTests: XCTestCase {
                             color: nil,
                             padding: 0,
                             displayTimeThreshold: displayTimeThreshold,
-                            minimumDisplayTime: minimumDisplayTime)
+                            minimumDisplayTime: minimumDisplayTime,
+                            textColor: nil)
     }
     
     func checkActivityViewAppeared() -> Bool {

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ NVActivityIndicatorView.DEFAULT_TYPE = .BallSpinFadeLoader
 NVActivityIndicatorView.DEFAULT_COLOR = UIColor.white
 ```
 
+- Default color of the text below the activity indicator view when using an `NVActivityIndicatorPresenter`. The presentor will use the activity indicator `color` for the text if it is set but a `textColor` is not. `DEFAULT_TEXT_COLOR` is only used when neither are set.
+
+```swift
+NVActivityIndicatorView.DEFAULT_TEXT_COLOR = UIColor.white
+```
+
 - Default padding of activity indicator view.
 
 ```swift


### PR DESCRIPTION
For example, I would like to have a orange activity indicator that displays well on white background, but use a black text since orange text is not as readable on that white background. Right now, the text color is always the same color as the activity indicator. 
This change allows the text color to be set separately when using the presenter ActivityData. For backwards compatibility, if color has been set but textColor has not, color will continue to be used for the text color. I default textColor does exist, but will only be used if neither color nor textColor are set (and the default is white, same as the old color default).