### PR TITLE
Display UI immediately if displayTimeThreshold = 0

### DIFF
--- a/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorPresenter.swift
@@ -130,7 +130,11 @@ public final class NVActivityIndicatorPresenter {
     public final func startAnimating(_ data: ActivityData) {
         guard showTimer == nil else { return }
         isStopAnimatingCalled = false
-        showTimer = scheduledTimer(data.displayTimeThreshold, selector: #selector(showTimerFired(_:)), data: data)
+        if data.displayTimeThreshold == 0 {
+            show(with: data)
+        } else {
+            showTimer = scheduledTimer(data.displayTimeThreshold, selector: #selector(showTimerFired(_:)), data: data)
+        }
     }
 
     /**


### PR DESCRIPTION
In my application I try to update the message set in the ActivityData but I never see that change because setMessage() is called before the timer show the original ActivityData.
This is because even with diplayTimeThreshold = 0, the call of the selector show() is placed at the end of the current execution stack, after my message update.

This pullRequest is proposal to avoid this by immediately calling show() if displayThimeThresold = 0.