### PR TITLE
Fix indicator view for auto layout

### DIFF
--- a/NVActivityIndicatorView/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/NVActivityIndicatorView/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -435,6 +435,15 @@ public final class NVActivityIndicatorView: UIView {
         return CGSize(width: bounds.width, height: bounds.height)
     }
 
+    public override var bounds: CGRect {
+        didSet {
+            // setup the animation again for the new bounds
+            if oldValue != bounds && isAnimating {
+                setUpAnimation()
+            }
+        }
+    }
+
     /**
      Start animating.
      */


### PR DESCRIPTION
This fixes the view when used with auto layout and an explicit frame isn't available when the view is created.