### PR TITLE
Handle starting while waiting to stop

### DIFF
--- a/Example/NVActivityIndicatorViewTests/NVActivityIndicatorPresenterTests.swift
+++ b/Example/NVActivityIndicatorViewTests/NVActivityIndicatorPresenterTests.swift
@@ -114,6 +114,30 @@ class NVActivityIndicatorPresenterTests: XCTestCase {
             XCTAssertFalse(self.checkActivityViewAppeared())
         }
     }
+    
+    func testStartStopStart() {
+        let activityData = createActivityData(displayTimeThreshold: 0,
+                                              minimumDisplayTime: 0)
+
+        XCTAssertFalse(checkActivityViewAppeared())
+        NVActivityIndicatorPresenter.sharedInstance.startAnimating(activityData)
+        
+        doAfter(approximateZero) {
+            XCTAssertTrue(self.checkActivityViewAppeared())
+            NVActivityIndicatorPresenter.sharedInstance.stopAnimating()
+            NVActivityIndicatorPresenter.sharedInstance.startAnimating(activityData)
+        }
+        
+        doAfter(approximateZero * 2) {
+            XCTAssertTrue(self.checkActivityViewAppeared())
+            NVActivityIndicatorPresenter.sharedInstance.stopAnimating()
+        }
+        
+        doAfter(approximateZero * 3) {
+            XCTAssertFalse(self.checkActivityViewAppeared())
+        }
+
+    }
 
     func testIsAnimating() {
         let activityData = createActivityData(displayTimeThreshold: 100,

--- a/Source/NVActivityIndicatorView/Presenter/NVActivityIndicatorPresenter.swift
+++ b/Source/NVActivityIndicatorView/Presenter/NVActivityIndicatorPresenter.swift
@@ -134,6 +134,7 @@ private struct NVActivityIndicatorPresenterStateAnimating: NVActivityIndicatorPr
         guard let activityData = presenter.data else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(activityData.minimumDisplayTime)) {
+            guard presenter.state == .waitingToStop else { return }
             presenter.stopAnimating()
         }
         presenter.state = .waitingToStop
@@ -142,7 +143,10 @@ private struct NVActivityIndicatorPresenterStateAnimating: NVActivityIndicatorPr
 
 private struct NVActivityIndicatorPresenterStateWaitingToStop: NVActivityIndicatorPresenterState {
     func startAnimating(presenter: NVActivityIndicatorPresenter) {
-        // Do nothing
+        presenter.stopAnimating()
+
+        guard let activityData = presenter.data else { return }
+        presenter.startAnimating(activityData)
     }
 
     func stopAnimating(presenter: NVActivityIndicatorPresenter) {


### PR DESCRIPTION
Fixed bug when the animation is in progress and you call stopAnimating and startAnimating in the same run loop iteration: added possibility to start animation from the waitingToStop state. 
The real example can be checked in the added unit test.