### PR TITLE
Don’t start/stop animating if unnecessary

### DIFF
--- a/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -499,6 +499,9 @@ public final class NVActivityIndicatorView: UIView {
      Start animating.
      */
     public final func startAnimating() {
+        guard !isAnimating else {
+            return
+        }
         isHidden = false
         isAnimating = true
         layer.speed = 1
@@ -509,6 +512,9 @@ public final class NVActivityIndicatorView: UIView {
      Stop animating.
      */
     public final func stopAnimating() {
+        guard isAnimating else {
+            return
+        }
         isHidden = true
         isAnimating = false
         layer.sublayers?.removeAll()


### PR DESCRIPTION
This change fixes a glitch in the solution reproduced when an animation was started multiple times.

Here is a gif showing the bug. Every time the button is tapped, `activityIndicatorView.startAnimating()` is called.
![oct-10-2018 18-57-48](https://user-images.githubusercontent.com/9628833/46768409-7266ea80-ccbe-11e8-930a-c79804bb7c33.gif)


With this change, the animation performs smoothly without any interrumptions, even after tapping the button multiple times:
![oct-11-2018 14-42-23](https://user-images.githubusercontent.com/9628833/46823214-f1622e80-cd63-11e8-942e-a5b21ea7bada.gif)
