### PR TITLE
Specified Swift version in podspec

### DIFF
--- a/NVActivityIndicatorView.podspec
+++ b/NVActivityIndicatorView.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target  = "8.0"
   s.tvos.deployment_target = "9.0"
+  s.swift_version = "4.0"
 
   s.source       = { :git => "https://github.com/ninjaprox/NVActivityIndicatorView.git", :tag => s.version }
 


### PR DESCRIPTION
NVActivityIndicatorView will not build for me in Xcode 10.1 unless I manually change the Swift version in the pod settings. This PR fixes it by specifying the swift version in the podspec.