### PR TITLE
Make NVActivityIndicatorType conform to CaseIterable

### DIFF
--- a/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -64,7 +64,7 @@ import UIKit
  - AudioEqualizer:          AudioEqualizer animation.
  - CircleStrokeSpin:        CircleStrokeSpin animation.
  */
-public enum NVActivityIndicatorType: Int {
+public enum NVActivityIndicatorType: Int, CaseIterable {
     /**
      Blank.
 
@@ -263,8 +263,7 @@ public enum NVActivityIndicatorType: Int {
      - returns: Instance of NVActivityIndicatorAnimationCircleStrokeSpin.
      */
     case circleStrokeSpin
-
-    static let allTypes = (blank.rawValue ... circleStrokeSpin.rawValue).map { NVActivityIndicatorType(rawValue: $0)! }
+    
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func animation() -> NVActivityIndicatorAnimationDelegate {
@@ -524,7 +523,7 @@ public final class NVActivityIndicatorView: UIView {
 
     // swiftlint:disable:next identifier_name
     func _setTypeName(_ typeName: String) {
-        for item in NVActivityIndicatorType.allTypes {
+        for item in NVActivityIndicatorType.allCases {
             if String(describing: item).caseInsensitiveCompare(typeName) == ComparisonResult.orderedSame {
                 type = item
                 break

--- a/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -263,7 +263,6 @@ public enum NVActivityIndicatorType: Int, CaseIterable {
      - returns: Instance of NVActivityIndicatorAnimationCircleStrokeSpin.
      */
     case circleStrokeSpin
-    
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func animation() -> NVActivityIndicatorAnimationDelegate {


### PR DESCRIPTION
It is a simple change. `allTypes` is removed and `NVActivityIndicatorType` conforms to `CaseIterable` protocol instead.