### PR TITLE
Make NVActivityIndicatorType conform to CaseIterable

### DIFF
--- a/Example/NVActivityIndicatorViewExample/ViewController.swift
+++ b/Example/NVActivityIndicatorViewExample/ViewController.swift
@@ -42,7 +42,7 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
         let cellHeight = Int(self.view.frame.height / CGFloat(rows))
 
         let presentingIndicatorTypes = NVActivityIndicatorType.allCases.filter { $0 != .blank }
-        
+
         for (index, indicatorType) in presentingIndicatorTypes.enumerated() {
             let x = index % cols * cellWidth
             let y = index / cols * cellHeight
@@ -85,8 +85,8 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
         let selectedIndicatorIndex = sender.tag
         let presentingIndicatorTypes = NVActivityIndicatorType.allCases.filter { $0 != .blank }
         let indicatorType = presentingIndicatorTypes[selectedIndicatorIndex]
-        
-        startAnimating(size, message: "Loading...", type:indicatorType, fadeInAnimation: nil)
+
+        startAnimating(size, message: "Loading...", type: indicatorType, fadeInAnimation:nil)
 
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
             NVActivityIndicatorPresenter.sharedInstance.setMessage("Authenticating...")

--- a/Example/NVActivityIndicatorViewExample/ViewController.swift
+++ b/Example/NVActivityIndicatorViewExample/ViewController.swift
@@ -41,22 +41,24 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
         let cellWidth = Int(self.view.frame.width / CGFloat(cols))
         let cellHeight = Int(self.view.frame.height / CGFloat(rows))
 
-        (NVActivityIndicatorType.ballPulse.rawValue ... NVActivityIndicatorType.circleStrokeSpin.rawValue).forEach {
-            let x = ($0 - 1) % cols * cellWidth
-            let y = ($0 - 1) / cols * cellHeight
+        let presentingIndicatorTypes = NVActivityIndicatorType.allCases.filter { $0 != .blank }
+        
+        for (index, indicatorType) in presentingIndicatorTypes.enumerated() {
+            let x = index % cols * cellWidth
+            let y = index / cols * cellHeight
             let frame = CGRect(x: x, y: y, width: cellWidth, height: cellHeight)
             let activityIndicatorView = NVActivityIndicatorView(frame: frame,
-                                                                type: NVActivityIndicatorType(rawValue: $0)!)
+                                        type: indicatorType)
             let animationTypeLabel = UILabel(frame: frame)
 
-            animationTypeLabel.text = String($0)
+            animationTypeLabel.text = String(index)
             animationTypeLabel.sizeToFit()
             animationTypeLabel.textColor = UIColor.white
             animationTypeLabel.frame.origin.x += 5
             animationTypeLabel.frame.origin.y += CGFloat(cellHeight) - animationTypeLabel.frame.size.height
 
             activityIndicatorView.padding = 20
-            if $0 == NVActivityIndicatorType.orbit.rawValue {
+            if indicatorType == NVActivityIndicatorType.orbit {
                 activityIndicatorView.padding = 0
             }
             self.view.addSubview(activityIndicatorView)
@@ -64,7 +66,7 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
             activityIndicatorView.startAnimating()
 
             let button: UIButton = UIButton(frame: frame)
-            button.tag = $0
+            button.tag = index
             #if swift(>=4.2)
             button.addTarget(self,
                              action: #selector(buttonTapped(_:)),
@@ -80,8 +82,11 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
 
     @objc func buttonTapped(_ sender: UIButton) {
         let size = CGSize(width: 30, height: 30)
-
-        startAnimating(size, message: "Loading...", type: NVActivityIndicatorType(rawValue: sender.tag)!, fadeInAnimation: nil)
+        let selectedIndicatorIndex = sender.tag
+        let presentingIndicatorTypes = NVActivityIndicatorType.allCases.filter { $0 != .blank }
+        let indicatorType = presentingIndicatorTypes[selectedIndicatorIndex]
+        
+        startAnimating(size, message: "Loading...", type:indicatorType, fadeInAnimation: nil)
 
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
             NVActivityIndicatorPresenter.sharedInstance.setMessage("Authenticating...")

--- a/Example/NVActivityIndicatorViewExample/ViewController.swift
+++ b/Example/NVActivityIndicatorViewExample/ViewController.swift
@@ -31,6 +31,10 @@ import NVActivityIndicatorView
 
 class ViewController: UIViewController, NVActivityIndicatorViewable {
 
+    private let presentingIndicatorTypes = {
+        return NVActivityIndicatorType.allCases.filter { $0 != .blank }
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -40,8 +44,6 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
         let rows = 8
         let cellWidth = Int(self.view.frame.width / CGFloat(cols))
         let cellHeight = Int(self.view.frame.height / CGFloat(rows))
-
-        let presentingIndicatorTypes = NVActivityIndicatorType.allCases.filter { $0 != .blank }
 
         for (index, indicatorType) in presentingIndicatorTypes.enumerated() {
             let x = index % cols * cellWidth
@@ -83,10 +85,9 @@ class ViewController: UIViewController, NVActivityIndicatorViewable {
     @objc func buttonTapped(_ sender: UIButton) {
         let size = CGSize(width: 30, height: 30)
         let selectedIndicatorIndex = sender.tag
-        let presentingIndicatorTypes = NVActivityIndicatorType.allCases.filter { $0 != .blank }
         let indicatorType = presentingIndicatorTypes[selectedIndicatorIndex]
 
-        startAnimating(size, message: "Loading...", type: indicatorType, fadeInAnimation:nil)
+        startAnimating(size, message: "Loading...", type: indicatorType, fadeInAnimation: nil)
 
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
             NVActivityIndicatorPresenter.sharedInstance.setMessage("Authenticating...")

--- a/Example/NVActivityIndicatorViewTests/NVActivityIndicatorTypeTests.swift
+++ b/Example/NVActivityIndicatorViewTests/NVActivityIndicatorTypeTests.swift
@@ -75,7 +75,7 @@ class NVActivityIndicatorTypeTests: XCTestCase {
         }
     }
 
-    func testAllTypes() {
-        XCTAssertEqual(NVActivityIndicatorType.allTypes.last, NVActivityIndicatorType.circleStrokeSpin)
+    func testAllCases() {
+        XCTAssertEqual(NVActivityIndicatorType.allCases.last, NVActivityIndicatorType.circleStrokeSpin)
     }
 }

--- a/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -64,7 +64,7 @@ import UIKit
  - AudioEqualizer:          AudioEqualizer animation.
  - CircleStrokeSpin:        CircleStrokeSpin animation.
  */
-public enum NVActivityIndicatorType: Int {
+public enum NVActivityIndicatorType: Int, CaseIterable {
     /**
      Blank.
 
@@ -263,8 +263,6 @@ public enum NVActivityIndicatorType: Int {
      - returns: Instance of NVActivityIndicatorAnimationCircleStrokeSpin.
      */
     case circleStrokeSpin
-
-    static let allTypes = (blank.rawValue ... circleStrokeSpin.rawValue).map { NVActivityIndicatorType(rawValue: $0)! }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func animation() -> NVActivityIndicatorAnimationDelegate {
@@ -524,7 +522,7 @@ public final class NVActivityIndicatorView: UIView {
 
     // swiftlint:disable:next identifier_name
     func _setTypeName(_ typeName: String) {
-        for item in NVActivityIndicatorType.allTypes {
+        for item in NVActivityIndicatorType.allCases {
             if String(describing: item).caseInsensitiveCompare(typeName) == ComparisonResult.orderedSame {
                 type = item
                 break

--- a/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
+++ b/Source/NVActivityIndicatorView/NVActivityIndicatorView.swift
@@ -64,7 +64,7 @@ import UIKit
  - AudioEqualizer:          AudioEqualizer animation.
  - CircleStrokeSpin:        CircleStrokeSpin animation.
  */
-public enum NVActivityIndicatorType: Int, CaseIterable {
+public enum NVActivityIndicatorType: CaseIterable {
     /**
      Blank.
 


### PR DESCRIPTION
It is a simple change. `allTypes` is removed and `NVActivityIndicatorType` conforms to `CaseIterable` protocol instead.