### PR TITLE
Fixed bundle identifier AppExtension for Xcode 10.2 compatibility

### DIFF
--- a/Source/NVActivityIndicatorView.xcodeproj/project.pbxproj
+++ b/Source/NVActivityIndicatorView.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -752,7 +753,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = me.vinhis.NVActivityIndicatorView;
+				PRODUCT_BUNDLE_IDENTIFIER = me.vinhis.NVActivityIndicatorView.AppExtension;
 				PRODUCT_NAME = NVActivityIndicatorViewAppExtension;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -775,7 +776,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = me.vinhis.NVActivityIndicatorView;
+				PRODUCT_BUNDLE_IDENTIFIER = me.vinhis.NVActivityIndicatorView.AppExtension;
 				PRODUCT_NAME = NVActivityIndicatorViewAppExtension;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Made this small fix to get this working in Xcode 10.2. We are using Carthage and we couldn't deploy our project because `NVActivityIndicatorView` and the extension had same bundle identifier.