### PR TITLE
fix(animation): Sometime animations does not start

### DIFF
--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallBeat.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallBeat.swift
@@ -35,7 +35,7 @@ class NVActivityIndicatorAnimationBallBeat: NVActivityIndicatorAnimationDelegate
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - circleSize) / 2
         let duration: CFTimeInterval = 0.7
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0.35, 0, 0.35]
 
         // Scale animation

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallGridBeat.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallGridBeat.swift
@@ -35,7 +35,7 @@ class NVActivityIndicatorAnimationBallGridBeat: NVActivityIndicatorAnimationDele
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let durations = [0.96, 0.93, 1.19, 1.13, 1.34, 0.94, 1.2, 0.82, 1.19]
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0.36, 0.4, 0.68, 0.41, 0.71, -0.15, -0.12, 0.01, 0.32]
         #if swift(>=4.2)
         let timingFunction = CAMediaTimingFunction(name: .default)

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallGridPulse.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallGridPulse.swift
@@ -35,7 +35,7 @@ class NVActivityIndicatorAnimationBallGridPulse: NVActivityIndicatorAnimationDel
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let durations: [CFTimeInterval] = [0.72, 1.02, 1.28, 1.42, 1.45, 1.18, 0.87, 1.45, 1.06]
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [ -0.06, 0.25, -0.17, 0.48, 0.31, 0.03, 0.46, 0.78, 0.45]
         #if swift(>=4.2)
         let timingFunction = CAMediaTimingFunction(name: .default)

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallPulse.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallPulse.swift
@@ -34,7 +34,7 @@ class NVActivityIndicatorAnimationBallPulse: NVActivityIndicatorAnimationDelegat
         let x: CGFloat = (layer.bounds.size.width - size.width) / 2
         let y: CGFloat = (layer.bounds.size.height - circleSize) / 2
         let duration: CFTimeInterval = 0.75
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [0.12, 0.24, 0.36]
         let timingFunction = CAMediaTimingFunction(controlPoints: 0.2, 0.68, 0.18, 1.08)
         let animation = CAKeyframeAnimation(keyPath: "transform.scale")

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallPulseSync.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallPulseSync.swift
@@ -36,7 +36,7 @@ class NVActivityIndicatorAnimationBallPulseSync: NVActivityIndicatorAnimationDel
         let y = (layer.bounds.size.height - circleSize) / 2
         let deltaY = (size.height / 2 - circleSize / 2) / 2
         let duration: CFTimeInterval = 0.6
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [0.07, 0.14, 0.21]
         #if swift(>=4.2)
         let timingFunciton = CAMediaTimingFunction(name: .easeInEaseOut)

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScaleMultiple.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScaleMultiple.swift
@@ -31,7 +31,7 @@ class NVActivityIndicatorAnimationBallScaleMultiple: NVActivityIndicatorAnimatio
 
     func setUpAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
         let duration: CFTimeInterval = 1
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0, 0.2, 0.4]
 
         // Scale animation

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScaleRippleMultiple.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScaleRippleMultiple.swift
@@ -31,7 +31,7 @@ class NVActivityIndicatorAnimationBallScaleRippleMultiple: NVActivityIndicatorAn
 
     func setUpAnimation(in layer: CALayer, size: CGSize, color: UIColor) {
         let duration: CFTimeInterval = 1.25
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0, 0.2, 0.4]
         let timingFunction = CAMediaTimingFunction(controlPoints: 0.21, 0.53, 0.56, 0.8)
 

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallSpinFadeLoader.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallSpinFadeLoader.swift
@@ -35,7 +35,7 @@ class NVActivityIndicatorAnimationBallSpinFadeLoader: NVActivityIndicatorAnimati
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let duration: CFTimeInterval = 1
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [0, 0.12, 0.24, 0.36, 0.48, 0.6, 0.72, 0.84]
 
         // Scale animation

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationCubeTransition.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationCubeTransition.swift
@@ -36,7 +36,7 @@ class NVActivityIndicatorAnimationCubeTransition: NVActivityIndicatorAnimationDe
         let deltaX = size.width - squareSize
         let deltaY = size.height - squareSize
         let duration: CFTimeInterval = 1.6
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [0, -0.8]
         #if swift(>=4.2)
         let timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScale.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScale.swift
@@ -34,7 +34,7 @@ class NVActivityIndicatorAnimationLineScale: NVActivityIndicatorAnimationDelegat
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let duration: CFTimeInterval = 1
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0.1, 0.2, 0.3, 0.4, 0.5]
         let timingFunction = CAMediaTimingFunction(controlPoints: 0.2, 0.68, 0.18, 1.08)
 

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScaleParty.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScaleParty.swift
@@ -34,7 +34,7 @@ class NVActivityIndicatorAnimationLineScaleParty: NVActivityIndicatorAnimationDe
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let durations: [CFTimeInterval] = [1.26, 0.43, 1.01, 0.73]
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [0.77, 0.29, 0.28, 0.74]
         #if swift(>=4.2)
         let timingFunction = CAMediaTimingFunction(name: .default)

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScalePulseOut.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScalePulseOut.swift
@@ -34,7 +34,7 @@ class NVActivityIndicatorAnimationLineScalePulseOut: NVActivityIndicatorAnimatio
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let duration: CFTimeInterval = 1
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0.4, 0.2, 0, 0.2, 0.4]
         let timingFunction = CAMediaTimingFunction(controlPoints: 0.85, 0.25, 0.37, 0.85)
 

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScalePulseOutRapid.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScalePulseOutRapid.swift
@@ -34,7 +34,7 @@ class NVActivityIndicatorAnimationLineScalePulseOutRapid: NVActivityIndicatorAni
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let duration: CFTimeInterval = 0.9
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes = [0.5, 0.25, 0, 0.25, 0.5]
         let timingFunction = CAMediaTimingFunction(controlPoints: 0.11, 0.49, 0.38, 0.78)
 

--- a/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineSpinFadeLoader.swift
+++ b/Source/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineSpinFadeLoader.swift
@@ -35,7 +35,7 @@ class NVActivityIndicatorAnimationLineSpinFadeLoader: NVActivityIndicatorAnimati
         let x = (layer.bounds.size.width - size.width) / 2
         let y = (layer.bounds.size.height - size.height) / 2
         let duration: CFTimeInterval = 1.2
-        let beginTime = CACurrentMediaTime()
+        let beginTime = layer.convertTime(CACurrentMediaTime(), from: nil)
         let beginTimes: [CFTimeInterval] = [0.12, 0.24, 0.36, 0.48, 0.6, 0.72, 0.84, 0.96]
         #if swift(>=4.2)
         let timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)


### PR DESCRIPTION
Reason: CACurrentMediaTime  of layer is not equal to global time of app. This time was affected by ScreenShot View, or app change states...
Solution: Covert global time to current layer time to ensure that they are sync.

@ninjaprox : Issue hôm bữa có nói trên fb nè :d 